### PR TITLE
Ensure resource groups have an environment tag

### DIFF
--- a/policies.tf
+++ b/policies.tf
@@ -40,6 +40,19 @@ resource "spacelift_policy_attachment" "plan" {
   stack_id  = spacelift_stack.managed.id
 }
 
+# Add a policy to enforce Azure standards
+resource "spacelift_policy" "azure-plan" {
+  type = "PLAN"
+
+  name = "Enforce Azure Policy"
+  body = file("${path.module}/policies/azure-policy.rego")
+}
+
+resource "spacelift_policy_attachment" "azure-plan-managed-stack" {
+  policy_id = spacelift_policy.azure-plan.id
+  stack_id  = spacelift_stack.managed.id
+}
+
 # PUSH POLICY
 #
 # This example Git push policy ignores all changes that are outside a project's

--- a/policies/azure-policy.rego
+++ b/policies/azure-policy.rego
@@ -1,0 +1,18 @@
+package spacelift
+
+# This policy enforces certain standards for Azure resources
+
+deny[sprintf("Resource groups must have the environment tag specified (%s)", [resource.address])] {
+    resource := resource_group[_]
+    resource.change.after.tags["environment"]
+}
+
+resource_group[resource] {
+    resource := created_resources[_]
+    resource.type == "azurerm_resource_group"
+}
+
+# Learn more about sampling policy evaluations here:
+#
+# https://docs.spacelift.io/concepts/policy#sampling-policy-inputs
+sample { true }


### PR DESCRIPTION
I've added a policy to ensure that any Azure resource groups that are created have an `environment` label specified.