### PR TITLE
Fix deny rule for environment tag missing

### DIFF
--- a/policies/azure-policy.rego
+++ b/policies/azure-policy.rego
@@ -4,7 +4,7 @@ package spacelift
 
 deny[sprintf("Resource groups must have the environment tag specified (%s)", [resource.address])] {
     resource := resource_group[_]
-    resource.change.after.tags["environment"]
+    not resource.change.after.tags["environment"]
 }
 
 resource_group[resource] {


### PR DESCRIPTION
I was accidentally saying that an environment label was not allowed, rather than enforcing that one must be specified, so I've flipped the logic.