### PR TITLE
Ensure stateful resources have `prevent_destroy`

### DIFF
--- a/policies/azure-policy.rego
+++ b/policies/azure-policy.rego
@@ -7,9 +7,23 @@ deny[sprintf("Resource groups must have the environment tag specified (%s)", [re
     not resource.change.after.tags["environment"]
 }
 
+deny[sprintf("Stateful resources must have 'prevent_destroy' enabled (%s)", [resource.address])] {
+    resource := stateful_resource[_]
+    not resource.change.after.lifecycle["prevent_destroy"] == true
+}
+
 resource_group[resource] {
     resource := created_resources[_]
     resource.type == "azurerm_resource_group"
+}
+
+stateful_resource[resource] {
+    stateful_resource_types := {
+        "azurerm_storage_account",
+        "azurerm_mssql_database"
+    }
+    resource := created_resources[_]
+    contains(resource.type, stateful_resource_types[_])
 }
 
 # Learn more about sampling policy evaluations here:


### PR DESCRIPTION
Add a new policy to ensure that certain types of resources have the `prevent_destroy` lifecycle set.