### PR TITLE
Add a storage account

### DIFF
--- a/managed-stack/storage.tf
+++ b/managed-stack/storage.tf
@@ -1,0 +1,14 @@
+resource "random_string" "storage-account-name" {
+  length           = 22
+  number           = true
+  upper            = false
+  special          = false
+}
+
+resource "azurerm_storage_account" "this" {
+  name                     = random_string.storage-account-name.result
+  resource_group_name      = azurerm_resource_group.this.name
+  location                 = azurerm_resource_group.this.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}


### PR DESCRIPTION
This should fail the OPA policy that ensures that certain resources have `prevent_destroy` set.